### PR TITLE
Add basic Flask clock app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+clock_app/instance/
+*.pyc
+*.db

--- a/clock_app/app.py
+++ b/clock_app/app.py
@@ -1,0 +1,95 @@
+from flask import Flask, request, jsonify
+from models import db, User, Availability, ClockEntry
+from datetime import datetime
+import uuid
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///clockapp.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+# simple token storage (not for production)
+tokens = {}
+
+db.init_app(app)
+
+def create_tables():
+    with app.app_context():
+        db.create_all()
+        if not User.query.filter_by(username='admin').first():
+            admin = User(username='admin', password='admin', role='admin')
+            db.session.add(admin)
+            db.session.commit()
+
+create_tables()
+
+@app.route('/login', methods=['POST'])
+def login():
+    data = request.json
+    user = User.query.filter_by(username=data.get('username'), password=data.get('password')).first()
+    if user:
+        token = str(uuid.uuid4())
+        tokens[token] = user.id
+        return jsonify({'token': token})
+    return jsonify({'error': 'invalid credentials'}), 401
+
+def require_auth(func):
+    def wrapper(*args, **kwargs):
+        token = request.headers.get('Authorization')
+        if not token or token not in tokens:
+            return jsonify({'error': 'unauthorized'}), 401
+        request.user_id = tokens[token]
+        return func(*args, **kwargs)
+    wrapper.__name__ = func.__name__
+    return wrapper
+
+@app.route('/availability', methods=['POST'])
+@require_auth
+def add_availability():
+    data = request.json
+    entry = Availability(user_id=request.user_id,
+                         day=data['day'],
+                         start_time=data['start_time'],
+                         end_time=data['end_time'])
+    db.session.add(entry)
+    db.session.commit()
+    return jsonify({'status': 'added'})
+
+@app.route('/availability/best', methods=['GET'])
+@require_auth
+def best_times():
+    user = User.query.get(request.user_id)
+    if user.role != 'admin':
+        return jsonify({'error': 'forbidden'}), 403
+    # naive algorithm: find overlap of all availabilities per day
+    result = {}
+    for day in ['Monday','Tuesday','Wednesday','Thursday','Friday']:
+        day_entries = Availability.query.filter_by(day=day).all()
+        if not day_entries:
+            continue
+        start = max(e.start_time for e in day_entries)
+        end = min(e.end_time for e in day_entries)
+        if start < end:
+            result[day] = f"{start}-{end}"
+    return jsonify(result)
+
+@app.route('/clock/in', methods=['POST'])
+@require_auth
+def clock_in():
+    entry = ClockEntry(user_id=request.user_id, clock_in=datetime.utcnow())
+    db.session.add(entry)
+    db.session.commit()
+    return jsonify({'status': 'clocked in', 'entry_id': entry.id})
+
+@app.route('/clock/out', methods=['POST'])
+@require_auth
+def clock_out():
+    entry_id = request.json.get('entry_id')
+    entry = ClockEntry.query.get(entry_id)
+    if not entry or entry.user_id != request.user_id:
+        return jsonify({'error': 'invalid entry'}), 400
+    entry.clock_out = datetime.utcnow()
+    db.session.commit()
+    return jsonify({'status': 'clocked out'})
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/clock_app/models.py
+++ b/clock_app/models.py
@@ -1,0 +1,23 @@
+from flask_sqlalchemy import SQLAlchemy
+from datetime import datetime
+
+db = SQLAlchemy()
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password = db.Column(db.String(120), nullable=False)
+    role = db.Column(db.String(20), nullable=False, default='employee')
+
+class Availability(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    day = db.Column(db.String(10), nullable=False)  # e.g., Monday
+    start_time = db.Column(db.String(5), nullable=False)  # HH:MM
+    end_time = db.Column(db.String(5), nullable=False)
+
+class ClockEntry(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    clock_in = db.Column(db.DateTime, default=datetime.utcnow)
+    clock_out = db.Column(db.DateTime)

--- a/clock_app/requirements.txt
+++ b/clock_app/requirements.txt
@@ -1,0 +1,3 @@
+Flask==3.0.0
+Flask-SQLAlchemy==3.1.1
+pytest==7.4.0

--- a/clock_app/tests/test_app.py
+++ b/clock_app/tests/test_app.py
@@ -1,0 +1,37 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import json
+from app import app, db, User
+
+app.testing = True
+client = app.test_client()
+
+
+def setup_module(module):
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        db.session.add(User(username='admin', password='admin', role='admin'))
+        db.session.add(User(username='emp', password='emp', role='employee'))
+        db.session.commit()
+
+
+def get_token(username, password):
+    resp = client.post('/login', json={'username': username, 'password': password})
+    data = json.loads(resp.data)
+    return data.get('token')
+
+
+def test_login():
+    token = get_token('admin', 'admin')
+    assert token
+
+
+def test_availability_and_best():
+    emp_token = get_token('emp', 'emp')
+    client.post('/availability', json={
+        'day': 'Monday', 'start_time': '09:00', 'end_time': '17:00'
+    }, headers={'Authorization': emp_token})
+    admin_token = get_token('admin', 'admin')
+    resp = client.get('/availability/best', headers={'Authorization': admin_token})
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add simple Flask app with login, availability and clocking routes
- implement SQLAlchemy models for users, availability, and clock entries
- provide basic pytest suite
- add Python ignores

## Testing
- `pip install -r clock_app/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886997938048323893d9fbbf5e43acc